### PR TITLE
added windows build, inject is now at bottom of windows

### DIFF
--- a/Distraction Shield/contentInjection/inject.html
+++ b/Distraction Shield/contentInjection/inject.html
@@ -1,7 +1,5 @@
 
-<br>
-<br>
-<div id="tds" class="row row-centered" style="text-align:center;" >
+<div id="tds" class="row row-centered" style="text-align:center; position:absolute; width:100%; bottom:0;" >
     <div id="tds_infoDiv" class="panel col-xs"
          style="
             display:inline-block;

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "start": "broccoli serve",
     "build": "rm -rf dist && broccoli build dist && webpack",
+    "build-windows": "rd /s /q dist && broccoli build dist && webpack",
     "test": "npm run build && mocha \"test/**/*-test.js\" "
   },
   "repository": {


### PR DESCRIPTION
windows users can now build with npm run build-windows
although I might be the only windows user, I find this useful!

and I implemented mircea's suggestion for the inject html