### PR TITLE
Storage quota fix

### DIFF
--- a/Distraction Shield/classes/BlockedSiteList.js
+++ b/Distraction Shield/classes/BlockedSiteList.js
@@ -52,7 +52,8 @@ export default class BlockedSiteList extends Array {
     }
 
     removeFromList(blockedSiteToDelete) {
-        this.splice(this.indexOf(blockedSiteToDelete), 1);
+        let index = this.map(function(e) { return e.domain; }).indexOf(blockedSiteToDelete.domain);
+        this.splice(index, 1);
     }
 
     updateInList(blockedSite){

--- a/Distraction Shield/modules/storage/StorageListener.js
+++ b/Distraction Shield/modules/storage/StorageListener.js
@@ -1,13 +1,14 @@
 /**
- * @module simple module that adds a listener which listens for changes in the storage.
+ * simple class that adds a listener which listens for changes in the storage.
  * Page that use data from the storage and need to be updated on change, will implement a function that defines what to
  * do with the changes and pass it on to the constructor of this class. This method will then fire upon the change of storage.
+ * @class StorageListener
  */
 
 export default class StorageListener {
     constructor(handleStorageChange) {
         /**
-         * Listener that makes sure that handleStorageChange is fired upon the sync.storage changing.
+         * Listener that makes sure that handleStorageChange is fired upon the storage changing.
          */
         chrome.storage.onChanged.addListener(changes => {
             handleStorageChange(changes)

--- a/Distraction Shield/modules/storage/storage.js
+++ b/Distraction Shield/modules/storage/storage.js
@@ -15,12 +15,14 @@ import * as constants  from '../../constants'
  * used to set items stored in the storage of the chrome api. Returns a promise
  * @param {string} dataKey key of the data to store
  * @param {string} dataValue value of data to store
+ * @param {boolean} isLocal used to distinguish between using local or sync storage (default sync)
  */
-function setStorage(dataKey, dataValue) {
+function setStorage(dataKey, dataValue, isLocal = false) {
     return new Promise(function (resolve, reject) {
+        let storage = (isLocal ? chrome.storage.local : chrome.storage.sync);
         let newObject = {};
         newObject[dataKey] = dataValue;
-        chrome.storage.sync.set(newObject, function () {
+        storage.set(newObject, function () {
             if (handleRuntimeError()) {
                 resolve();
             } else {
@@ -33,10 +35,12 @@ function setStorage(dataKey, dataValue) {
 /**
  * used to retrieve items stored from the storage of the chrome api. Returns a promise due to asynchronousness
  * @param {string} dataKey key of the data to store
+ * @param {boolean} isLocal used to distinguish between using local or sync storage (default sync)
  */
-function getStorage(dataKey) {
+function getStorage(dataKey, isLocal = false) {
     return new Promise(function (resolve, reject) {
-        chrome.storage.sync.get(dataKey, function (output) {
+        let storage = (isLocal ? chrome.storage.local : chrome.storage.sync);
+        storage.get(dataKey, function (output) {
             if (handleRuntimeError()) {
                 if (dataKey === null || dataKey.length > 1) {
                     resolve(output);
@@ -146,21 +150,21 @@ export function setExerciseTimeList(statList) {
 /* ---------------- Logger --------------- */
 
 export function getLogs(callback) {
-    getStorage([constants.tds_logs]).then(output => {
+    getStorage([constants.tds_logs], true).then(output => {
         callback(output);
     });
 }
 
 export function setLogs(logfile) {
-    return setStorage(constants.tds_logs, logfile);
+    return setStorage(constants.tds_logs, logfile, true);
 }
 
 export function clearLogs(){
-    chrome.storage.sync.remove(constants.tds_logs);
+    chrome.storage.local.remove(constants.tds_logs);
 }
 
 export function setLogFile(data){
-    return setStorage(constants.tds_logfile, data);
+    return setStorage(constants.tds_logfile, data, true);
 }
 
 /**

--- a/Distraction Shield/optionsPage/classes/GreenToRedSlider.js
+++ b/Distraction Shield/optionsPage/classes/GreenToRedSlider.js
@@ -4,11 +4,22 @@ import {logToFile} from '../../modules/logger'
 
 /**
  * class that connects a <div> with a span and slider together with all the functionality.
- * I.E. changing colour, updating eachother's values and functionality to be added to the html_elements
+ * I.E. changing colour, updating eachother's values and functionality to be added to the html_elements.
+ * The structure this class wants to receive is:
+ *      <div id=sliderID>, holding all other components
+ *          <input type=range id=sliderID + "-range">
+ *          <span id=sliderID + "-value">
+*       </div>
+ *
+ * @abstract
+ * @class GreenToRedSlider
  */
 export default class GreenToRedSlider {
 
     constructor(sliderID, saveFunction) {
+        if (new.target === GreenToRedSlider) {
+            throw new TypeError("Cannot construct instances directly, GreenToRedSlider is an abstract class");
+        }
         this.saveValue = saveFunction;
         this.sliderDiv = $(sliderID);
         this.sliderRange = $(this.sliderDiv.find(sliderID + "-range"));

--- a/Distraction Shield/optionsPage/classes/IntervalSlider.js
+++ b/Distraction Shield/optionsPage/classes/IntervalSlider.js
@@ -1,0 +1,21 @@
+import GreenToRedSlider from './GreenToRedSlider'
+import * as storage from '../../modules/storage/storage'
+/**
+ * Class that subclasses the GreenToRedSlider to a single purpose. This class updates the interceptionInterval
+ * of the user's settings.
+ *
+ * @class IntervalSlider
+ */
+
+export default class IntervalSlider extends GreenToRedSlider {
+
+    constructor(sliderID) {
+        super(sliderID, function(value) {
+            storage.getSettings((settings_object) => {
+                settings_object.interceptionInterval = parseInt(value);
+                storage.setSettings(settings_object);
+            });
+        });
+    }
+
+}

--- a/Distraction Shield/optionsPage/classes/TurnOffSlider.js
+++ b/Distraction Shield/optionsPage/classes/TurnOffSlider.js
@@ -8,6 +8,9 @@ import * as logger from '../../modules/logger'
  * subclass of the GreenToRedSlider, this also connects a button to the set of html_elements.
  * Furthermore it connects a userSettings item and fires functions according to the values of the
  * html_elements in order to manipulate the settings and let the user specify what he/she wants from the extension
+ * Specifically turning the interception off or back on for a given amount of time
+ *
+ * @class TurnOffSlider
  */
 export default class TurnOffSlider extends GreenToRedSlider {
 

--- a/Distraction Shield/optionsPage/htmlFunctionality.js
+++ b/Distraction Shield/optionsPage/htmlFunctionality.js
@@ -1,4 +1,3 @@
-import GreenToRedSlider from './classes/GreenToRedSlider'
 import * as constants from '../constants'
 import * as storage from '../modules/storage/storage'
 import * as logger from '../modules/logger'
@@ -33,24 +32,17 @@ function submitOnKeyPress(html_elem, submitFunc) {
 
 /* -------------------- Logic for the mode selection -------------------- */
 
-export function initModeSelection(buttonGroup, settings_object) {
-    $("input[name=" + buttonGroup + "]").change(function () {
-        let selectedMode = $("input[name=" + buttonGroup + "]:checked").val();
-        if (selectedMode === 'pro') {
-            settings_object.mode = constants.modes.pro;
-        } else {
-            settings_object.mode = constants.modes.lazy;
-        }
-        storage.setSettings(settings_object);
-        logger.logToFile(constants.logEventType.changed, `mode`, `${settings_object.mode.label}`, constants.logType.settings);
-    });
-}
-
-/* -------------------- Interval slider -------------------- */
-
-export function initIntervalSlider(settings_object) {
-    return new GreenToRedSlider('#interval-slider', function (value) {
-        settings_object.interceptionInterval = parseInt(value);
-        storage.setSettings(settings_object);
+export function initModeSelection(buttonGroup) {
+    $("input[name=" + buttonGroup + "]").change(() => {
+        storage.getSettings((settings_object) => {
+            let selectedMode = $("input[name=" + buttonGroup + "]:checked").val();
+            if (selectedMode === 'pro') {
+                settings_object.mode = constants.modes.pro;
+            } else {
+                settings_object.mode = constants.modes.lazy;
+            }
+            storage.setSettings(settings_object);
+            logger.logToFile(constants.logEventType.changed, `mode`, `${settings_object.mode.label}`, constants.logType.settings);
+        });
     });
 }

--- a/Distraction Shield/optionsPage/options.js
+++ b/Distraction Shield/optionsPage/options.js
@@ -5,6 +5,7 @@ import StorageListener from "../modules/storage/StorageListener"
 import UserSettings from '../classes/UserSettings'
 import BlockedSiteList from '../classes/BlockedSiteList'
 import BlacklistTable from './classes/BlacklistTable'
+import IntervalSlider from './classes/IntervalSlider'
 import TurnOffSlider from './classes/TurnOffSlider'
 import * as connectDataToHtml from './connectDataToHtml'
 import * as htmlFunctionality from './htmlFunctionality'
@@ -39,7 +40,7 @@ document.addEventListener("DOMContentLoaded", function () {
  */
 function initOptionsPage() {
     storage.getAll(function (output) {
-        connectHtmlFunctionality(output.tds_settings);
+        connectHtmlFunctionality();
         connectStorageDataToHtml(output);
     });
 }
@@ -47,9 +48,9 @@ function initOptionsPage() {
 /**
  * connect the functionality to the different html_elements on the optionspage.
  */
-function connectHtmlFunctionality(userSettings) {
-    htmlFunctionality.initModeSelection(modeGroup, userSettings);
-    intervalSlider = htmlFunctionality.initIntervalSlider(userSettings);
+function connectHtmlFunctionality() {
+    htmlFunctionality.initModeSelection(modeGroup);
+    intervalSlider = new IntervalSlider('#interval-slider');
     blockedSiteListTable = new BlacklistTable($('#blacklistTable'));
     turnOffSlider = new TurnOffSlider('#turnOff-slider');
     htmlFunctionality.connectButton($('#turnOff-slider-offBtn'), turnOffSlider.offButtonFunc);

--- a/Distraction Shield/optionsPage/options.js
+++ b/Distraction Shield/optionsPage/options.js
@@ -131,7 +131,10 @@ function openFeedbackForm() {
 
 function restartTour() {
     chrome.tabs.getCurrent(tab => {
-        chrome.tabs.update(tab.id, {url: chrome.runtime.getURL('introTour/introTour.html')});
+        if (!tab)
+            openTabSingleton(chrome.runtime.getURL('introTour/introTour.html'));
+        else
+            chrome.tabs.update(tab.id, {url: chrome.runtime.getURL('introTour/introTour.html')});
     })
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -355,8 +355,9 @@
       "dev": true
     },
     "babel-preset-env": {
-      "version": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.5.1.tgz",
-      "integrity": "sha1-0uymrxee3yfNwwWoSCD2AbRW3Qs=",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.5.2.tgz",
+      "integrity": "sha1-zUrpCm6Utwn5c3SzPl+LmDVWre8=",
       "dev": true
     },
     "babel-register": {
@@ -2172,9 +2173,9 @@
       "dev": true
     },
     "npm": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-5.0.1.tgz",
-      "integrity": "sha512-QGwOzpe5Exdh/k0tM9SbYIKEo73XICxkNAV7K9ACokKKTO1yZsIIXglmxxP+FJHhbm8Zbd23HauhyA05eG/Xug==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-5.0.3.tgz",
+      "integrity": "sha512-mnDS+181aU952rCrHnLr1eyHOUbpCE2VrTYt1N/MXK0JRgUneofhHzuDXiwrNY0JmNb1n0VrHdwDEqS6x1iukQ==",
       "dependencies": {
         "abbrev": {
           "version": "1.1.0",
@@ -2197,9 +2198,9 @@
           "integrity": "sha1-XeYEFb2gcbs3EnhUyGT0GyMlRTk="
         },
         "aproba": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.1.1.tgz",
-          "integrity": "sha1-ldNgDwdxCqDpKYxyatXs8urLq6s="
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.1.2.tgz",
+          "integrity": "sha512-ZpYajIfO0j2cOFTO955KUMIKNmj6zhX8kVztMAxFsDaMwz+9Z9SV0uou2pC9HJqcfpffOsjnbrDMvkNy+9RXPw=="
         },
         "archy": {
           "version": "1.0.0",
@@ -2212,9 +2213,9 @@
           "integrity": "sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw="
         },
         "cacache": {
-          "version": "9.2.6",
-          "resolved": "https://registry.npmjs.org/cacache/-/cacache-9.2.6.tgz",
-          "integrity": "sha512-YK0Z5Np5t755edPL6gfdCeGxtU0rcW/DBhYhYVDckT+7AFkCCtedf2zru5NRbBLFk6e7Agi/RaqTOAfiaipUfg==",
+          "version": "9.2.8",
+          "resolved": "https://registry.npmjs.org/cacache/-/cacache-9.2.8.tgz",
+          "integrity": "sha512-nA3gmaDPEsFWqI5eYAe35IfvW54yGJ3ns2wDopWf4iDA3fkhBNsdvnYp4NrL+L7ysMt0/isM84Mwi+b4l8/pMQ==",
           "dependencies": {
             "y18n": {
               "version": "3.2.1",
@@ -2694,9 +2695,9 @@
           }
         },
         "node-gyp": {
-          "version": "3.6.1",
-          "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.6.1.tgz",
-          "integrity": "sha1-GVYQZ/8YVGSt7UeCEmgfR/1XjLw=",
+          "version": "3.6.2",
+          "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.6.2.tgz",
+          "integrity": "sha1-m/vlRWIoYoSDjnUOrAUpWFP6HGA=",
           "dependencies": {
             "minimatch": {
               "version": "3.0.4",
@@ -2764,9 +2765,9 @@
           "integrity": "sha1-1K7N/VGlPjcjt7L5Oy7ijjB7wNc="
         },
         "npm-package-arg": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-5.0.1.tgz",
-          "integrity": "sha1-CagW4/RaVJ492vM+m65eezEHeHI="
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-5.1.1.tgz",
+          "integrity": "sha512-67wPa1moaLvn9YAVLLECpGe+v3jL82pBDTE2jMxLOQHd0kWBLnmtCqbxrFagp5pVNFukqmtYRruK3wfoeVTZ2g=="
         },
         "npm-registry-client": {
           "version": "8.3.0",
@@ -2895,14 +2896,14 @@
           }
         },
         "pacote": {
-          "version": "2.7.26",
-          "resolved": "https://registry.npmjs.org/pacote/-/pacote-2.7.26.tgz",
-          "integrity": "sha512-/DT9ehDr49F+6lMNXHvEe/AjTxYgT+jejGtK7wFLAKaYsxdTqewpncXvm3jzYAOF2tEfAwA54duktrA7JkCH+g==",
+          "version": "2.7.30",
+          "resolved": "https://registry.npmjs.org/pacote/-/pacote-2.7.30.tgz",
+          "integrity": "sha512-xFxozbxytemyfNPZmkL2seTD15mozK8ghov9npjBO4YTs3SnA8I55aiN94eZJ+XhLKzbN8yXqQMr9ti4c3WIDw==",
           "dependencies": {
             "make-fetch-happen": {
-              "version": "2.4.10",
-              "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-2.4.10.tgz",
-              "integrity": "sha512-ZD9SRSC0TGlThOnnlPdDuUcKE74D8XeriPoNYEtWgBGAzKp4P7tIDWN6LvLvMSkd23HDbaUMsu9g3dO3NavZIg==",
+              "version": "2.4.11",
+              "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-2.4.11.tgz",
+              "integrity": "sha512-3dbl9CVS9Y0hqVzcD5HBYnaNUGw3XWpmeTqGT6ACRrmKS7WKwSDfv5+Gd1K0X/Mt52hsvZwtOH8hrNIulYkhag==",
               "dependencies": {
                 "agentkeepalive": {
                   "version": "3.1.0",
@@ -3228,20 +3229,15 @@
           }
         },
         "read-package-tree": {
-          "version": "5.1.5",
-          "resolved": "https://registry.npmjs.org/read-package-tree/-/read-package-tree-5.1.5.tgz",
-          "integrity": "sha1-rOfmOBx2hPlwqqmPx8XStmat2rY="
+          "version": "5.1.6",
+          "resolved": "https://registry.npmjs.org/read-package-tree/-/read-package-tree-5.1.6.tgz",
+          "integrity": "sha512-FCX1aT3GWyY658wzDICef4p+n0dB+ENRct8E/Qyvppj6xVpOYerBHfUu7OP5Rt1/393Tdglguf5ju5DEX4wZNg=="
         },
         "readable-stream": {
-          "version": "2.2.9",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
-          "integrity": "sha1-z3jsb0ptHrQ9JkiMrJfwQudLf8g=",
+          "version": "2.2.10",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.10.tgz",
+          "integrity": "sha512-HQEnnoV404e0EtwB9yNiuk2tJ+egeVC8Y9QBAxzDg8DBJt4BzRp+yQuIb/t3FIWkSTmIi+sgx7yVv/ZM0GNoqw==",
           "dependencies": {
-            "buffer-shims": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
-              "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E="
-            },
             "core-util-is": {
               "version": "1.0.2",
               "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
@@ -3258,9 +3254,9 @@
               "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
             },
             "string_decoder": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.0.tgz",
-              "integrity": "sha1-8G9BFXtmTYYGn4S9vcmw2KsoFmc="
+              "version": "1.0.1",
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
+              "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg="
             },
             "util-deprecate": {
               "version": "1.0.2",
@@ -3569,9 +3565,9 @@
           "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0="
         },
         "safe-buffer": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
-          "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c="
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.0.tgz",
+          "integrity": "sha512-aSLEDudu6OoRr/2rU609gRmnYboRLxgDG1z9o2Q0os7236FwvcqIOO8r8U5JUEwivZOhDaKlFO4SbPTJYyBEyQ=="
         },
         "semver": {
           "version": "5.3.0",
@@ -3642,9 +3638,9 @@
           }
         },
         "ssri": {
-          "version": "4.1.4",
-          "resolved": "https://registry.npmjs.org/ssri/-/ssri-4.1.4.tgz",
-          "integrity": "sha512-CfN7rEZZi9/eLoED+vfKpgEPXdev5D5FV2fCih8j1e+rOSrKwoXzq3HVGy5ybu5mj94lrQ1X2oP+xBjLNtPUQQ=="
+          "version": "4.1.5",
+          "resolved": "https://registry.npmjs.org/ssri/-/ssri-4.1.5.tgz",
+          "integrity": "sha512-TaLitc/pZH1UF8LCgZWdbssPiOUcPjBmIJsYJa+YltP77mY2qQ0Y2b+VS4C9RbZRH1GPMt4zckqqBd7GE/61ew=="
         },
         "strip-ansi": {
           "version": "3.0.1",
@@ -4738,37 +4734,44 @@
       }
     },
     "webpack": {
-      "version": "https://registry.npmjs.org/webpack/-/webpack-2.5.1.tgz",
-      "integrity": "sha1-YXQvDPivVVuHRgqc2Lui8ePuL84=",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-2.6.1.tgz",
+      "integrity": "sha1-LgRX8KuxrF3zqxBsacZy8jZ4Xwc=",
       "dev": true,
       "dependencies": {
         "async": {
-          "version": "https://registry.npmjs.org/async/-/async-2.4.0.tgz",
-          "integrity": "sha1-SZAgDxjqW4N8LMT4wDGmmFw4VhE=",
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.4.1.tgz",
+          "integrity": "sha1-YqVrJ5yYoR0JhwlqAcw+6463u9c=",
           "dev": true
         },
         "camelcase": {
-          "version": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
           "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
           "dev": true
         },
         "cliui": {
-          "version": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
           "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
           "dev": true
         },
         "source-map": {
-          "version": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+          "version": "0.5.6",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
           "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
           "dev": true
         },
         "supports-color": {
-          "version": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+          "version": "3.2.3",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
           "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
           "dev": true
         },
         "yargs": {
-          "version": "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
+          "version": "6.6.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
           "integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
           "dev": true
         }


### PR DESCRIPTION
Fixed the bug which was discovered last night. 
Logs are now stored in the local storage, which has a limit of 5,242,880 bytes, which will never be reached. 
To do this, I have modified the get & setStorage functions inside the storage module to take another parameter 'isLocal'. This is set to false by default.
Also, the tour button on the extension page's optionspage is fixed, sliders & mode selector now properly retrieve current settings before storing settings changes.